### PR TITLE
Simplify hotkey logic and add a unit test

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,12 @@
+module.exports = {
+  presets: [
+    [
+      '@babel/preset-env',
+      {
+        targets: {
+          node: 'current',
+        },
+      },
+    ],
+  ],
+};

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Simple extension that allows you to mute and unmute yourself with the space bar instead of fumbling around trying to click the button.",
   "scripts": {
     "build": "webpack",
-    "build:dev": "NODE_ENV=development webpack"
+    "build:dev": "NODE_ENV=development webpack",
+    "test": "jest"
   },
   "repository": {
     "type": "git",
@@ -24,8 +25,9 @@
     "copy-webpack-plugin": "^5.1.1",
     "css-loader": "^3.5.2",
     "html-webpack-plugin": "^4.2.0",
+    "jest": "^26.0.1",
     "style-loader": "^1.1.4",
-    "webpack": "^4.42.1",
+    "webpack": "^4.43.0",
     "webpack-cli": "^3.3.11",
     "zip-webpack-plugin": "^3.0.0"
   },

--- a/src/js/hotkey.js
+++ b/src/js/hotkey.js
@@ -1,5 +1,10 @@
 import codeToString from "keycode";
 
+const ShiftKey = 16;
+const CtrlKey = 17;
+const AltKey = 18;
+const MetaKey = 91;
+
 class Hotkey {
   constructor({
     keyCode,
@@ -44,29 +49,24 @@ class Hotkey {
   }
 
   matchKeydown(event) {
-    return (
-      this.keys.ctrlKey == event.ctrlKey &&
-      this.keys.altKey == event.altKey &&
-      this.keys.shiftKey == event.shiftKey &&
-      this.keys.metaKey == event.metaKey &&
-      (this.keys.keyCode == event.keyCode ||
-        ([16, 17, 18, 91].includes(event.keyCode) &&
-          this.keys.keyCode === undefined))
-    );
+	  return this.matchKeyup(event);
   }
 
   matchKeyup(event) {
-    if (this.keys.keyCode && this.keys.keyCode == event.keyCode) {
-      return true;
-    }
-
-    return (
-      (this.keys.ctrlKey && !event.ctrlKey) ||
-      (this.keys.altKey && !event.altKey) ||
-      (this.keys.shiftKey && !event.shiftKey) ||
-      (this.keys.metaKey && !event.metaKey)
-    );
+	  let keyCode = null;
+	  if (this.keys.keyCode !== undefined) {
+		  keyCode = this.keys.keyCode;
+	  } else if (this.keys.ctrlKey) {
+		  keyCode = CtrlKey;
+	  } else if (this.keys.altKey) {
+		  keyCode = AltKey;
+	  } else if (this.keys.shiftKey) {
+		  keyCode = ShiftKey;
+	  } else if (this.keys.metaKey) {
+		  keyCode = MetaKey;
+	  }
+	  return keyCode === event.keyCode;
   }
 }
 
-export default Hotkey;
+export {ShiftKey, CtrlKey, AltKey, MetaKey, Hotkey};

--- a/src/js/hotkey.js
+++ b/src/js/hotkey.js
@@ -49,23 +49,23 @@ class Hotkey {
   }
 
   matchKeydown(event) {
-	  return this.matchKeyup(event);
+    return this.matchKeyup(event);
   }
 
   matchKeyup(event) {
-	  let keyCode = null;
-	  if (this.keys.keyCode !== undefined) {
-		  keyCode = this.keys.keyCode;
-	  } else if (this.keys.ctrlKey) {
-		  keyCode = CtrlKey;
-	  } else if (this.keys.altKey) {
-		  keyCode = AltKey;
-	  } else if (this.keys.shiftKey) {
-		  keyCode = ShiftKey;
-	  } else if (this.keys.metaKey) {
-		  keyCode = MetaKey;
-	  }
-	  return keyCode === event.keyCode;
+    let keyCode = null;
+    if (this.keys.keyCode !== undefined) {
+      keyCode = this.keys.keyCode;
+    } else if (this.keys.ctrlKey) {
+      keyCode = CtrlKey;
+    } else if (this.keys.altKey) {
+      keyCode = AltKey;
+    } else if (this.keys.shiftKey) {
+      keyCode = ShiftKey;
+    } else if (this.keys.metaKey) {
+      keyCode = MetaKey;
+    }
+    return keyCode === event.keyCode;
   }
 }
 

--- a/src/js/hotkey.test.js
+++ b/src/js/hotkey.test.js
@@ -1,0 +1,18 @@
+import {AltKey, Hotkey, MetaKey} from "./hotkey.js"
+
+test("dummy key press events", () => {
+	let key = new Hotkey({altKey: true});
+
+	// These are to assert that a KeyboardEvent.altKey value does not determine
+	// the result of Hotkey.matchKey* functions.
+	expect(key.matchKeydown({altKey: true, keyCode: AltKey})).toBeTruthy();
+	expect(key.matchKeydown({altKey: false, keyCode: AltKey})).toBeTruthy();
+	expect(key.matchKeyup({altKey: true, keyCode: AltKey})).toBeTruthy();
+	expect(key.matchKeyup({altKey: false, keyCode: AltKey})).toBeTruthy();
+
+	// These are to assert that any incorrect keyCode will result in no matches
+	expect(key.matchKeydown({altKey: true, keyCode: MetaKey})).toBeFalsy();
+	expect(key.matchKeydown({altKey: false, keyCode: MetaKey})).toBeFalsy();
+	expect(key.matchKeyup({altKey: true, keyCode: MetaKey})).toBeFalsy();
+	expect(key.matchKeyup({altKey: false, keyCode: MetaKey})).toBeFalsy();
+});

--- a/src/js/hotkey.test.js
+++ b/src/js/hotkey.test.js
@@ -1,18 +1,18 @@
 import {AltKey, Hotkey, MetaKey} from "./hotkey.js"
 
 test("dummy key press events", () => {
-	let key = new Hotkey({altKey: true});
+  let key = new Hotkey({altKey: true});
 
-	// These are to assert that a KeyboardEvent.altKey value does not determine
-	// the result of Hotkey.matchKey* functions.
-	expect(key.matchKeydown({altKey: true, keyCode: AltKey})).toBeTruthy();
-	expect(key.matchKeydown({altKey: false, keyCode: AltKey})).toBeTruthy();
-	expect(key.matchKeyup({altKey: true, keyCode: AltKey})).toBeTruthy();
-	expect(key.matchKeyup({altKey: false, keyCode: AltKey})).toBeTruthy();
+  // These are to assert that a KeyboardEvent.altKey value does not determine
+  // the result of Hotkey.matchKey* functions.
+  expect(key.matchKeydown({altKey: true, keyCode: AltKey})).toBeTruthy();
+  expect(key.matchKeydown({altKey: false, keyCode: AltKey})).toBeTruthy();
+  expect(key.matchKeyup({altKey: true, keyCode: AltKey})).toBeTruthy();
+  expect(key.matchKeyup({altKey: false, keyCode: AltKey})).toBeTruthy();
 
-	// These are to assert that any incorrect keyCode will result in no matches
-	expect(key.matchKeydown({altKey: true, keyCode: MetaKey})).toBeFalsy();
-	expect(key.matchKeydown({altKey: false, keyCode: MetaKey})).toBeFalsy();
-	expect(key.matchKeyup({altKey: true, keyCode: MetaKey})).toBeFalsy();
-	expect(key.matchKeyup({altKey: false, keyCode: MetaKey})).toBeFalsy();
+  // These are to assert that any incorrect keyCode will result in no matches
+  expect(key.matchKeydown({altKey: true, keyCode: MetaKey})).toBeFalsy();
+  expect(key.matchKeydown({altKey: false, keyCode: MetaKey})).toBeFalsy();
+  expect(key.matchKeyup({altKey: true, keyCode: MetaKey})).toBeFalsy();
+  expect(key.matchKeyup({altKey: false, keyCode: MetaKey})).toBeFalsy();
 });

--- a/src/js/storage.js
+++ b/src/js/storage.js
@@ -1,4 +1,4 @@
-import Hotkey from "./hotkey";
+import { Hotkey } from "./hotkey";
 
 export function getSavedValues(fn) {
   chrome.storage.sync.get(

--- a/src/options.js
+++ b/src/options.js
@@ -1,5 +1,5 @@
 import "./css/options.css";
-import Hotkey from "./js/hotkey";
+import { Hotkey } from "./js/hotkey";
 import { getSavedValues, saveHotkey, saveMuteOnJoin } from "./js/storage";
 
 const editButton = document.getElementById("hotkey_edit"),

--- a/src/ptt.js
+++ b/src/ptt.js
@@ -1,4 +1,4 @@
-import Hotkey from "./js/hotkey";
+import { Hotkey } from "./js/hotkey";
 import { getSavedValues, addChangeListener } from "./js/storage";
 import { elementReady } from "./js/element-ready";
 


### PR DESCRIPTION
Hey! I tried to take a swing at fixing https://github.com/MoonriseCo/google-meet-push-to-talk/issues/4 . Let me know what you think!

# Test plan

Added a new unit test and ran `node_modules/.bin/jest` and it passed.

Built a new extension via `npm_package_version=1.1.2 NODE_ENV=development node_modules/.bin/webpack` and loaded it into my browser. Opened a meeting on meet.google.com and tried toggling my hot key. Previously, a quick tap of the hot key (mine was Alt) would unmute me. Followed by a different hot key (space/shift/command) would re-mute me. With this diff, the other hot keys no longer toggles keyups! 