### PR TITLE
Use page language instead of browser language

### DIFF
--- a/src/ptt.js
+++ b/src/ptt.js
@@ -14,7 +14,7 @@ const MIC_ON = {
 
 let currentHotkey, keydownToggle, keyupToggle;
 
-const currentLanguage = () => window.navigator.language.split("-")[0];
+const currentLanguage = () => document.documentElement.lang;
 
 const micButtonSelector = (tip) => `[data-tooltip*='${tip}']`;
 


### PR DESCRIPTION
Before, the extension didn't work when the language of Google Meet didn't match the browser language.
Now it uses the language of the page instead.